### PR TITLE
Curl Error using curl_errno

### DIFF
--- a/StatusPage/StatusPage.php
+++ b/StatusPage/StatusPage.php
@@ -45,8 +45,8 @@ class StatusPage
 		
 		if( ! $result = curl_exec($curl)) 
 		{	 
-        trigger_error(curl_error($ch)); 
-		return False;
+        		trigger_error(curl_error($ch)); 
+			return False;
 		}	 
 		
 		curl_close($curl);

--- a/StatusPage/StatusPage.php
+++ b/StatusPage/StatusPage.php
@@ -42,13 +42,17 @@ class StatusPage
 			CURLOPT_USERAGENT => 'UptimeRobot Public Status Page',
 			CURLOPT_CONNECTTIMEOUT => 400
 		));
-		$checks = json_decode(curl_exec($curl),TRUE);
+		
+		if( ! $result = curl_exec($curl)) 
+		{	 
+        trigger_error(curl_error($ch)); 
+		return False;
+		}	 
+		
 		curl_close($curl);
-
-		//Checks to make sure curl is happy
-		if(curl_errno($curl)){
-			return False;
-		}
+		
+		$checks = json_decode($result,TRUE);
+	
 
 		//Checks to make sure UptimeRobot didn't return any errors
 		if ($checks[stat] != 'ok'){


### PR DESCRIPTION
For some reason on 1 of my hosts when I tested this, it caused errors due to the use of `if(curl_errno($curl)){`.

As such I revamped the curl logic to test if curl had an error differently. This seemed to work in my case.
