### PR TITLE
Mistake in Ajax.php fixed: percent comparison on value, not on array

### DIFF
--- a/StatusPage/Ajax.php
+++ b/StatusPage/Ajax.php
@@ -49,7 +49,7 @@ if (!$checks){
 					foreach ($check->getUptimeRatios() as $uptimeratio) {
 						if ($uptimeratio >= $percentGreen){
 							echo "<td class=\"green text-center hide-for-small-only\">$uptimeratio%</td>";
-						}elseif ($check->getUptimeRatios() >= $percentYellow) {
+						}elseif ($uptimeratio >= $percentYellow) {
 							echo "<td class=\"yellow text-center hide-for-small-only\">$uptimeratio%</td>";
 						}else{
 							echo "<td class=\"red text-center hide-for-small-only\">$uptimeratio%</td>";


### PR DESCRIPTION
A small bug causing colors on percentages to never display red, always yellow or green.
