### PR TITLE
Adding desiredOrder to configuration

### DIFF
--- a/js/app/config.js
+++ b/js/app/config.js
@@ -26,4 +26,15 @@ var config = {
 
         //I guess you can hide the footer, but it would make me sad :(
         showFooter: true,
+
+        /* Manually set the order in which to display each monitor
+           
+           To use it set desiredOrder to be an object where the keys are the uptimeRobot ids 
+           and the values are comparable using the > operator
+           eg: { '3736363636': 0, 
+                 '2474744747': 1, 
+                  ...
+        */
+        desiredOrder: undefined
+
     };

--- a/js/app/main.js
+++ b/js/app/main.js
@@ -41,6 +41,12 @@ $( document ).ready(function() {
                     allChecks.push(prettifyCode(obj));
                 });
 
+                if (config.desiredOrder) {
+                    allChecks.sort(function(a,b) {
+                        return config.desiredOrder[a.id] > config.desiredOrder[b.id] ? 1 : -1;
+                    });
+                }
+
                 pageInfo = {
                     checks: allChecks,
                     headers: json.headers


### PR DESCRIPTION
Adding a property desiredOrder to the frontend JS config. This allows the setting of a fixed, arbitrary order for checks to be displayed. The sort is performed only if the property is set.

This isn't the most elegant thing, but it is very useful for anyone that is making their status page public since the relative importance of various services doesn't correlate to anything else one could use to order them.
